### PR TITLE
fix: single-branch clone 릴리스 경로 보강

### DIFF
--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -18,16 +18,21 @@ reading version sources or changing release metadata:
 
 ```bash
 bash -euo pipefail <<'SH'
-git checkout develop
-git fetch origin develop
-git pull --ff-only origin develop
+git fetch origin '+refs/heads/develop:refs/remotes/origin/develop'
+if git show-ref --verify --quiet refs/heads/develop; then
+    git checkout develop
+else
+    git checkout -b develop --track origin/develop
+fi
+git merge --ff-only origin/develop
 test "$(git rev-parse HEAD)" = "$(git rev-parse origin/develop)" || { echo "ERROR: local develop differs from origin/develop" >&2; exit 1; }
 test -z "$(git status --porcelain)" || { echo "ERROR: develop worktree is not clean" >&2; exit 1; }
 SH
 ```
 
-Stop immediately if checkout, fetch, pull, remote equality, or the clean-tree
-assertion fails. Exact equality rejects a clean local-ahead develop branch.
+Stop immediately if fetch, checkout/create, fast-forward merge, remote equality,
+or the clean-tree assertion fails. Exact equality rejects a clean local-ahead
+develop branch.
 
 ### 2. Select a version above every published or installed version
 
@@ -116,12 +121,12 @@ git add .claude-plugin/plugin.json .claude-plugin/marketplace.json pyproject.tom
 git commit -m "release: v{version}"
 RELEASE_SHA="$(git rev-parse HEAD)"
 git push origin develop
-git fetch origin develop
+git fetch origin '+refs/heads/develop:refs/remotes/origin/develop'
 test "$(git rev-parse origin/develop)" = "$RELEASE_SHA" || { echo "ERROR: origin/develop does not equal the release commit" >&2; exit 1; }
 
+git fetch origin '+refs/heads/main:refs/remotes/origin/main'
 git checkout main
-git fetch origin main
-git pull --ff-only origin main
+git merge --ff-only origin/main
 test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" || { echo "ERROR: local main differs from origin/main" >&2; exit 1; }
 git merge --no-ff "$RELEASE_SHA" -m "Merge develop: v{version}"
 MAIN_SHA="$(git rev-parse HEAD)"
@@ -135,7 +140,7 @@ test "$TAG_SHA" = "$MAIN_SHA" || { echo "ERROR: release tag does not point to ma
 git merge-base --is-ancestor "$RELEASE_SHA" "$TAG_SHA"
 
 git push origin main
-git fetch origin main
+git fetch origin '+refs/heads/main:refs/remotes/origin/main'
 test "$(git rev-parse origin/main)" = "$MAIN_SHA" || { echo "ERROR: origin/main does not equal the verified main commit" >&2; exit 1; }
 git merge-base --is-ancestor "$RELEASE_SHA" "$(git rev-parse origin/main)"
 git push origin v{version}
@@ -155,8 +160,9 @@ Update the marketplace clone and request the plugin update:
 
 ```bash
 bash -euo pipefail <<'SH'
+git -C "$HOME/.claude/plugins/marketplaces/lee-ji-hoon" fetch origin '+refs/heads/main:refs/remotes/origin/main'
 git -C "$HOME/.claude/plugins/marketplaces/lee-ji-hoon" checkout main
-git -C "$HOME/.claude/plugins/marketplaces/lee-ji-hoon" pull --ff-only origin main
+git -C "$HOME/.claude/plugins/marketplaces/lee-ji-hoon" merge --ff-only origin/main
 SH
 ```
 
@@ -184,7 +190,7 @@ Claude Code must be restarted before using the released plugin.
 
 ## Checklist
 
-- [ ] Latest develop is fetched, pulled with `--ff-only`, exactly equal to `origin/develop`, and clean
+- [ ] Latest develop is fetched by explicit refspec, merged with `--ff-only`, exactly equal to `origin/develop`, and clean
 - [ ] Requested semver is greater than every remote and cached version
 - [ ] All three metadata files equal `{version}` and CHANGELOG is updated
 - [ ] Python, both shell suites, and shell syntax gates pass

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -160,9 +160,12 @@ Update the marketplace clone and request the plugin update:
 
 ```bash
 bash -euo pipefail <<'SH'
+test -z "$(git -C "$HOME/.claude/plugins/marketplaces/lee-ji-hoon" status --porcelain)" || { echo "ERROR: marketplace checkout is not clean" >&2; exit 1; }
 git -C "$HOME/.claude/plugins/marketplaces/lee-ji-hoon" fetch origin '+refs/heads/main:refs/remotes/origin/main'
 git -C "$HOME/.claude/plugins/marketplaces/lee-ji-hoon" checkout main
 git -C "$HOME/.claude/plugins/marketplaces/lee-ji-hoon" merge --ff-only origin/main
+test "$(git -C "$HOME/.claude/plugins/marketplaces/lee-ji-hoon" rev-parse HEAD)" = "$(git -C "$HOME/.claude/plugins/marketplaces/lee-ji-hoon" rev-parse origin/main)" || { echo "ERROR: local marketplace main differs from origin/main" >&2; exit 1; }
+test -z "$(git -C "$HOME/.claude/plugins/marketplaces/lee-ji-hoon" status --porcelain)" || { echo "ERROR: marketplace checkout is not clean" >&2; exit 1; }
 SH
 ```
 

--- a/tests/test_version_contract.py
+++ b/tests/test_version_contract.py
@@ -1,10 +1,24 @@
 import json
 import re
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+DEVELOP_REFSPEC = "+refs/heads/develop:refs/remotes/origin/develop"
+MAIN_REFSPEC = "+refs/heads/main:refs/remotes/origin/main"
+
+
+def run_git(*args, check=True):
+    return subprocess.run(
+        ["git"] + list(args),
+        check=check,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
 
 
 def read_project_version():
@@ -134,9 +148,10 @@ class VersionContractTests(unittest.TestCase):
     def test_release_skill_orders_version_gate_and_publication(self):
         release = read_release_skill()
         required_in_order = [
+            "git fetch origin '{}'".format(DEVELOP_REFSPEC),
             "git checkout develop",
-            "git fetch origin develop",
-            "git pull --ff-only origin develop",
+            "git checkout -b develop --track origin/develop",
+            "git merge --ff-only origin/develop",
             'test "$(git rev-parse HEAD)" = "$(git rev-parse origin/develop)"',
             'test -z "$(git status --porcelain)"',
             "remote tag",
@@ -152,16 +167,23 @@ class VersionContractTests(unittest.TestCase):
             "git add .claude-plugin/plugin.json .claude-plugin/marketplace.json pyproject.toml CHANGELOG.md",
             "git commit",
             "git push origin develop",
+            "git fetch origin '{}'".format(DEVELOP_REFSPEC),
+            'test "$(git rev-parse origin/develop)" = "$RELEASE_SHA"',
+            "git fetch origin '{}'".format(MAIN_REFSPEC),
             "git checkout main",
-            "git fetch origin main",
-            "git pull --ff-only origin main",
+            "git merge --ff-only origin/main",
             'test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"',
             'git merge --no-ff "$RELEASE_SHA" -m "Merge develop: v{version}"',
             "main HEAD",
             "git tag -a",
             "git push origin main",
+            "git fetch origin '{}'".format(MAIN_REFSPEC),
+            'test "$(git rev-parse origin/main)" = "$MAIN_SHA"',
             "git push origin v{version}",
             "marketplace clone",
+            "git -C \"$HOME/.claude/plugins/marketplaces/lee-ji-hoon\" fetch origin '{}'".format(
+                MAIN_REFSPEC
+            ),
             "$HOME/.claude/plugins/cache/lee-ji-hoon/account/{version}",
         ]
 
@@ -201,9 +223,10 @@ class VersionContractTests(unittest.TestCase):
             self,
             develop_block,
             [
+                "git fetch origin '{}'".format(DEVELOP_REFSPEC),
                 "git checkout develop",
-                "git fetch origin develop",
-                "git pull --ff-only origin develop",
+                "git checkout -b develop --track origin/develop",
+                "git merge --ff-only origin/develop",
                 'test "$(git rev-parse HEAD)" = "$(git rev-parse origin/develop)"',
                 'test -z "$(git status --porcelain)"',
             ],
@@ -212,13 +235,138 @@ class VersionContractTests(unittest.TestCase):
             self,
             main_block,
             [
+                "git fetch origin '{}'".format(MAIN_REFSPEC),
                 "git checkout main",
-                "git fetch origin main",
-                "git pull --ff-only origin main",
+                "git merge --ff-only origin/main",
                 'test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"',
                 'git merge --no-ff "$RELEASE_SHA" -m "Merge develop: v{version}"',
             ],
         )
+
+    def test_release_skill_supports_single_branch_fetch_configuration(self):
+        release = read_release_skill()
+        develop_block = block_containing(release, "git checkout develop")
+        publication = block_containing(release, 'git commit -m "release: v{version}"')
+        marketplace = block_containing(
+            release,
+            'git -C "$HOME/.claude/plugins/marketplaces/lee-ji-hoon" checkout main',
+        )
+
+        self.assertNotIn("git pull", develop_block)
+        self.assertNotIn("git pull", publication)
+        self.assertNotIn("git pull", marketplace)
+        self.assertNotIn("\ngit fetch origin develop\n", release)
+        self.assertNotIn("\ngit fetch origin main\n", release)
+        assert_markers_in_order(
+            self,
+            develop_block,
+            [
+                "git fetch origin '{}'".format(DEVELOP_REFSPEC),
+                "if git show-ref --verify --quiet refs/heads/develop; then",
+                "git checkout develop",
+                "git checkout -b develop --track origin/develop",
+                "git merge --ff-only origin/develop",
+                'test "$(git rev-parse HEAD)" = "$(git rev-parse origin/develop)"',
+                'test -z "$(git status --porcelain)"',
+            ],
+        )
+        assert_markers_in_order(
+            self,
+            publication,
+            [
+                "git push origin develop",
+                "git fetch origin '{}'".format(DEVELOP_REFSPEC),
+                'test "$(git rev-parse origin/develop)" = "$RELEASE_SHA"',
+                "git fetch origin '{}'".format(MAIN_REFSPEC),
+                "git checkout main",
+                "git merge --ff-only origin/main",
+                'test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"',
+                'git merge --no-ff "$RELEASE_SHA" -m "Merge develop: v{version}"',
+                'test "$(git rev-parse "$MAIN_SHA^2")" = "$RELEASE_SHA"',
+            ],
+        )
+        assert_markers_in_order(
+            self,
+            marketplace,
+            [
+                "git -C \"$HOME/.claude/plugins/marketplaces/lee-ji-hoon\" fetch origin '{}'".format(
+                    MAIN_REFSPEC
+                ),
+                'git -C "$HOME/.claude/plugins/marketplaces/lee-ji-hoon" checkout main',
+                'git -C "$HOME/.claude/plugins/marketplaces/lee-ji-hoon" merge --ff-only origin/main',
+            ],
+        )
+
+    def test_skill_develop_refspec_materializes_tracking_ref_in_single_branch_clone(self):
+        release = read_release_skill()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            origin = root / "origin.git"
+            seed = root / "seed"
+            clone = root / "clone"
+
+            run_git("init", "--bare", "-q", str(origin))
+            run_git("init", "-q", "-b", "main", str(seed))
+            run_git("-C", str(seed), "config", "user.name", "test")
+            run_git("-C", str(seed), "config", "user.email", "test@example.invalid")
+            run_git("-C", str(seed), "commit", "-q", "--allow-empty", "-m", "initial")
+            run_git("-C", str(seed), "branch", "develop")
+            run_git("-C", str(seed), "remote", "add", "origin", str(origin))
+            run_git("-C", str(seed), "push", "-q", "origin", "main", "develop")
+            run_git(
+                "clone",
+                "-q",
+                "--single-branch",
+                "--branch",
+                "main",
+                str(origin),
+                str(clone),
+            )
+
+            fetch_config = run_git(
+                "-C", str(clone), "config", "--get-all", "remote.origin.fetch"
+            ).stdout.splitlines()
+            self.assertEqual([MAIN_REFSPEC], fetch_config)
+
+            run_git("-C", str(clone), "fetch", "-q", "origin", "develop")
+            plain_ref = run_git(
+                "-C",
+                str(clone),
+                "show-ref",
+                "--verify",
+                "--quiet",
+                "refs/remotes/origin/develop",
+                check=False,
+            )
+            self.assertNotEqual(
+                0,
+                plain_ref.returncode,
+                "source-only fetch must reproduce the missing tracking ref",
+            )
+
+            refspec_match = re.search(re.escape(DEVELOP_REFSPEC), release)
+            self.assertIsNotNone(
+                refspec_match,
+                "release skill must carry the destination refspec used by this fixture",
+            )
+            skill_refspec = refspec_match.group(0)
+            run_git("-C", str(clone), "fetch", "-q", "origin", skill_refspec)
+            tracked = run_git(
+                "-C",
+                str(clone),
+                "show-ref",
+                "--verify",
+                "--quiet",
+                "refs/remotes/origin/develop",
+                check=False,
+            )
+            self.assertEqual(0, tracked.returncode)
+            self.assertEqual(
+                run_git("-C", str(seed), "rev-parse", "develop").stdout.strip(),
+                run_git(
+                    "-C", str(clone), "rev-parse", "refs/remotes/origin/develop"
+                ).stdout.strip(),
+            )
 
     def test_release_skill_verifies_exact_release_sha_before_each_publication(self):
         publication = block_containing(read_release_skill(), 'git commit -m "release: v{version}"')
@@ -240,9 +388,11 @@ class VersionContractTests(unittest.TestCase):
                 'git commit -m "release: v{version}"',
                 'RELEASE_SHA="$(git rev-parse HEAD)"',
                 "git push origin develop",
-                "git fetch origin develop",
+                "git fetch origin '{}'".format(DEVELOP_REFSPEC),
                 'test "$(git rev-parse origin/develop)" = "$RELEASE_SHA"',
+                "git fetch origin '{}'".format(MAIN_REFSPEC),
                 "git checkout main",
+                "git merge --ff-only origin/main",
                 'git merge --no-ff "$RELEASE_SHA" -m "Merge develop: v{version}"',
                 'MAIN_SHA="$(git rev-parse HEAD)"',
                 'test "$MAIN_SHA" != "$RELEASE_SHA"',
@@ -253,7 +403,7 @@ class VersionContractTests(unittest.TestCase):
                 'test "$TAG_SHA" = "$MAIN_SHA"',
                 'git merge-base --is-ancestor "$RELEASE_SHA" "$TAG_SHA"',
                 "git push origin main",
-                "git fetch origin main",
+                "git fetch origin '{}'".format(MAIN_REFSPEC),
                 'test "$(git rev-parse origin/main)" = "$MAIN_SHA"',
                 "git push origin v{version}",
                 'REMOTE_TAG_SHA="$(git ls-remote --tags origin "refs/tags/v{version}^{}"',
@@ -280,10 +430,15 @@ class VersionContractTests(unittest.TestCase):
         self.assertIn(clean_command, release, "release must assert a clean develop tree")
 
         checkout_position = release.index("git checkout develop")
-        pull_position = release.index(
-            "git pull --ff-only origin develop", checkout_position
+        merge_position = release.find(
+            "git merge --ff-only origin/develop", checkout_position
         )
-        clean_position = release.index(clean_command, pull_position)
+        self.assertNotEqual(
+            -1,
+            merge_position,
+            "develop must be fast-forwarded from the fetched tracking ref",
+        )
+        clean_position = release.index(clean_command, merge_position)
         metadata_position = release.index(".claude-plugin/plugin.json", clean_position)
         gate_end = release.index(gate_end_marker, metadata_position) + len(
             gate_end_marker

--- a/tests/test_version_contract.py
+++ b/tests/test_version_contract.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 import subprocess
 import tempfile
@@ -9,12 +10,65 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 DEVELOP_REFSPEC = "+refs/heads/develop:refs/remotes/origin/develop"
 MAIN_REFSPEC = "+refs/heads/main:refs/remotes/origin/main"
+MARKETPLACE_PATH = '$HOME/.claude/plugins/marketplaces/lee-ji-hoon'
+MARKETPLACE_CLEAN_GUARD = (
+    'test -z "$(git -C "'
+    + MARKETPLACE_PATH
+    + '" status --porcelain)" || '
+    + '{ echo "ERROR: marketplace checkout is not clean" >&2; exit 1; }'
+)
+MARKETPLACE_EQUALITY_GUARD = (
+    'test "$(git -C "'
+    + MARKETPLACE_PATH
+    + '" rev-parse HEAD)" = "$(git -C "'
+    + MARKETPLACE_PATH
+    + '" rev-parse origin/main)" || '
+    + '{ echo "ERROR: local marketplace main differs from origin/main" >&2; exit 1; }'
+)
 
 
 def run_git(*args, check=True):
     return subprocess.run(
         ["git"] + list(args),
         check=check,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def create_single_branch_marketplace_fixture(root):
+    origin = root / "origin.git"
+    seed = root / "seed"
+    home = root / "home"
+    clone = home / ".claude" / "plugins" / "marketplaces" / "lee-ji-hoon"
+
+    run_git("init", "--bare", "-q", str(origin))
+    run_git("init", "-q", "-b", "main", str(seed))
+    run_git("-C", str(seed), "config", "user.name", "test")
+    run_git("-C", str(seed), "config", "user.email", "test@example.invalid")
+    run_git("-C", str(seed), "commit", "-q", "--allow-empty", "-m", "initial")
+    run_git("-C", str(seed), "remote", "add", "origin", str(origin))
+    run_git("-C", str(seed), "push", "-q", "origin", "main")
+    clone.parent.mkdir(parents=True)
+    run_git(
+        "clone",
+        "-q",
+        "--single-branch",
+        "--branch",
+        "main",
+        str(origin),
+        str(clone),
+    )
+    return origin, seed, home, clone
+
+
+def run_release_block(block, home):
+    return subprocess.run(
+        ["bash"],
+        check=False,
+        env=dict(os.environ, HOME=str(home)),
+        input=block,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
@@ -289,13 +343,61 @@ class VersionContractTests(unittest.TestCase):
             self,
             marketplace,
             [
+                MARKETPLACE_CLEAN_GUARD,
                 "git -C \"$HOME/.claude/plugins/marketplaces/lee-ji-hoon\" fetch origin '{}'".format(
                     MAIN_REFSPEC
                 ),
                 'git -C "$HOME/.claude/plugins/marketplaces/lee-ji-hoon" checkout main',
                 'git -C "$HOME/.claude/plugins/marketplaces/lee-ji-hoon" merge --ff-only origin/main',
+                MARKETPLACE_EQUALITY_GUARD,
+                MARKETPLACE_CLEAN_GUARD,
             ],
         )
+
+    def test_marketplace_cache_block_rejects_dirty_checkout_before_fetch(self):
+        marketplace = block_containing(
+            read_release_skill(),
+            'git -C "$HOME/.claude/plugins/marketplaces/lee-ji-hoon" checkout main',
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            _, seed, home, clone = create_single_branch_marketplace_fixture(Path(tmp))
+            initial_sha = run_git("-C", str(clone), "rev-parse", "HEAD").stdout.strip()
+            run_git("-C", str(seed), "commit", "-q", "--allow-empty", "-m", "remote")
+            run_git("-C", str(seed), "push", "-q", "origin", "main")
+            (clone / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+
+            result = run_release_block(marketplace, home)
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertEqual(
+                initial_sha,
+                run_git("-C", str(clone), "rev-parse", "HEAD").stdout.strip(),
+                "dirty checkout must fail before merge mutation",
+            )
+            self.assertEqual(
+                initial_sha,
+                run_git("-C", str(clone), "rev-parse", "origin/main").stdout.strip(),
+                "dirty checkout must fail before fetch mutation",
+            )
+
+    def test_marketplace_cache_block_rejects_local_main_ahead(self):
+        marketplace = block_containing(
+            read_release_skill(),
+            'git -C "$HOME/.claude/plugins/marketplaces/lee-ji-hoon" checkout main',
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            _, _, home, clone = create_single_branch_marketplace_fixture(Path(tmp))
+            run_git("-C", str(clone), "config", "user.name", "test")
+            run_git("-C", str(clone), "config", "user.email", "test@example.invalid")
+            run_git("-C", str(clone), "commit", "-q", "--allow-empty", "-m", "local-ahead")
+
+            result = run_release_block(marketplace, home)
+
+            self.assertNotEqual(
+                0,
+                result.returncode,
+                "clean local-ahead main must fail exact remote equality",
+            )
 
     def test_skill_develop_refspec_materializes_tracking_ref_in_single_branch_clone(self):
         release = read_release_skill()


### PR DESCRIPTION
## Root cause

실제 marketplace clone은 `origin/main`만 fetch하도록 구성됩니다. 이 환경에서 `git fetch origin develop`은 FETCH_HEAD만 갱신하고 `origin/develop` remote-tracking ref를 만들거나 갱신하지 않아 릴리스 절차가 stale ref를 읽었습니다.

## Change

- develop/main을 destination이 포함된 explicit refspec으로 fetch
- local develop이 없으면 tracking branch를 안전 생성
- ff-only 최신화 뒤 exact remote equality 검증
- marketplace cache는 pre/post clean 및 local-ahead를 fail-closed
- temp single-branch bare remote fixture로 기존 실패와 수정 동작 재현

## Verification

- Homebrew/system Python: 각각 51 tests passed
- hook/install shell suites: ALL PASS
- release bash blocks, shell syntax, diff-check: PASS
- 독립 리뷰: Critical/Important/Minor 없음

v2.5.6 릴리스 전 실제 canonical clone preflight에서 발견한 follow-up입니다.